### PR TITLE
fix: Add cml trigger condition, auto mount data bucket

### DIFF
--- a/.github/workflows/python-pr-cml.yaml
+++ b/.github/workflows/python-pr-cml.yaml
@@ -27,9 +27,6 @@ on:
       cloud-permissions-set:
         required: true
         type: string
-      bucket:
-        required: false
-        type: string
       command:
         required: true
         type: string
@@ -40,6 +37,8 @@ on:
 
     secrets:
       GCP_CREDENTIALS:
+        required: true
+      GOOGLE_SAINET_DATASET_BUCKET:
         required: true
       CML_GITHUB_APP_PEM:
         required: true
@@ -150,10 +149,9 @@ jobs:
           sudo apt-get update && sudo apt-get install gcsfuse
 
       - name: Mount Bucket
-        if: ${{ inputs.bucket != '' }}
         run: |
-          mkdir -p bucket
-          gcsfuse ${{ inputs.bucket }} bucket/
+          mkdir -p ${{ secrets.GOOGLE_SAINET_DATASET_BUCKET }}
+          gcsfuse ${{ secrets.GOOGLE_SAINET_DATASET_BUCKET }} ${{ secrets.GOOGLE_SAINET_DATASET_BUCKET }}/
 
       - name: Setup GPU Drivers
         if: ${{ inputs.cloud-gpu != 'nogpu'}}
@@ -172,5 +170,5 @@ jobs:
           path: ${{ inputs.output-dir }}
 
       - name: Unmount Bucket
-        if: ${{ inputs.bucket != '' && always() }}
-        run: fusermount -u bucket/
+        if: ${{ always() }}
+        run: fusermount -u ${{ secrets.GOOGLE_SAINET_DATASET_BUCKET }}/

--- a/.github/workflows/python-pr-cml.yaml
+++ b/.github/workflows/python-pr-cml.yaml
@@ -47,8 +47,30 @@ on:
         required: true
 
 jobs:
+  init:
+    runs-on: ubuntu-latest
+    outputs:
+      message: ${{ steps.get-message.outputs.message }}"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          # for pull_request so we can do HEAD^2
+          fetch-depth: 2
+
+      - name: Get commit message
+        id: get-message
+        run: |
+          if [[ '${{ github.event_name }}' == 'push' ]]; then
+            echo ::set-output name=message::$(git log --format=%B -n 1 HEAD)
+          elif [[ '${{ github.event_name }}' == 'pull_request' ]]; then
+            echo ::set-output name=message::$(git log --format=%B -n 1 HEAD^2)
+          fi
+
   deploy-runner:
     runs-on: ubuntu-latest
+    needs: init
+    if: ${{ startsWith(needs.init.outputs.message, 'cml') }}
     env:
       GOOGLE_APPLICATION_CREDENTIALS_DATA: ${{ secrets.GCP_CREDENTIALS }}
     steps:

--- a/.github/workflows/python-pr-cml.yaml
+++ b/.github/workflows/python-pr-cml.yaml
@@ -150,8 +150,8 @@ jobs:
 
       - name: Mount Bucket
         run: |
-          mkdir -p ${{ secrets.GOOGLE_SAINET_DATASET_BUCKET }}
-          gcsfuse ${{ secrets.GOOGLE_SAINET_DATASET_BUCKET }} ${{ secrets.GOOGLE_SAINET_DATASET_BUCKET }}/
+          mkdir -p dataset-bucket
+          gcsfuse ${{ secrets.GOOGLE_SAINET_DATASET_BUCKET }} dataset-bucket/
 
       - name: Setup GPU Drivers
         if: ${{ inputs.cloud-gpu != 'nogpu'}}


### PR DESCRIPTION
Restricts the runner to only being triggered when people start their commit with `cml` in a conventional commit pattern -  `cml:` or `cml(api):`