### PR TITLE
fix: lock super-linter to 4.9.5

### DIFF
--- a/.github/workflows/python-pr-lint.yaml
+++ b/.github/workflows/python-pr-lint.yaml
@@ -22,7 +22,7 @@ jobs:
           path: 'workflows'
 
       - name: Lint Code Base
-        uses: github/super-linter/slim@v4
+        uses: github/super-linter/slim@v4.9.5
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: main


### PR DESCRIPTION
Pylint has suddenly started always failing on super-linter. The most likely explanation seems to be v4.9.6 released 5 hours ago. I think doing this should lock us to v4.9.5 which should fix things for now.