### PR TITLE
fix: Only lint files from the specified directory in a python monorepo

### DIFF
--- a/.github/workflows/python-pr-lint.yaml
+++ b/.github/workflows/python-pr-lint.yaml
@@ -35,6 +35,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           IGNORE_GITIGNORED_FILES: true
           IGNORE_GENERATED_FILES: true
+          FILTER_REGEX_INCLUDE: ${{ format('{0}/*', inputs.directory) }}
           # Skip flake8 as configuring it is annoying and
           # it's redundant to pylint
           VALIDATE_PYTHON_FLAKE8: false


### PR DESCRIPTION
This is needed to fix some weird linting errors in the demos monorepo https://github.com/spark-64/demos/pull/33
Basically the current linting is running through all the files in the whole repo each time (with different config from the `pyproject.toml` files) and is causing conflicting linting requirements between the projects.

This is a mono repo so linting shouldn't behave like that as these folders should be seperate. This only didn't cause issues previously because of how simple the other folders have been!

Based on documentation it seems like this will work (not really sure how to test this though other than just merging and checking 🙃)